### PR TITLE
Stable-baseline3 implementation

### DIFF
--- a/experiments/abstraction/abstraction_network.py
+++ b/experiments/abstraction/abstraction_network.py
@@ -13,14 +13,19 @@ class abstraction_network:
 			self.Pr_a_given_z=tf.compat.v1.placeholder(tf.float32, [None,self.num_abstract_states], name = 'prob_of_all_a_given_z')
 			h=self.obs
 			for _ in range(params['abstraction_network_hidden_layers']):
-				h=tf.layers.dense(
-		            inputs = h,
+				# h=tf.layers.dense(
+		        #     inputs = h,
+		        #     units = params['abstraction_network_hidden_nodes'],
+		        #     activation = tf.nn.relu)
+				
+				h=tf.keras.layers.Dense(
 		            units = params['abstraction_network_hidden_nodes'],
-		            activation = tf.nn.relu)
+		            activation = tf.nn.relu)(h)
+				
 
-			self.logits=tf.layers.dense(
-	            inputs = h,
-	            units = self.num_abstract_states)
+			self.logits=tf.keras.layers.Dense(
+	            # inputs = h,
+	            units = self.num_abstract_states)(h)
 
 			self.Pr_z_given_s = tf.nn.softmax(self.logits)
 			self.Pr_z_given_s=tf.clip_by_value(
@@ -29,11 +34,9 @@ class abstraction_network:
 				    clip_value_max=0.9999,
 				)
 
-			self.loss=-tf.reduce_mean(tf.multiply(self.Pr_a_given_z,tf.log(self.Pr_z_given_s)))
-														  
+			self.loss=-tf.reduce_mean(tf.multiply(self.Pr_a_given_z,tf.compat.v1.log(self.Pr_z_given_s)))							  
 											
-									
-			self.optimizer = tf.train.AdamOptimizer(learning_rate=self.learning_rate).minimize(self.loss)
+			self.optimizer = tf.compat.v1.train.AdamOptimizer(learning_rate=self.learning_rate).minimize(self.loss)
 
 			#self.optimizer = tf.train.GradientDescentOptimizer(learning_rate=self.learning_rate).minimize(self.loss)
 	def predict(self,samples):

--- a/experiments/abstraction/abstraction_network.py
+++ b/experiments/abstraction/abstraction_network.py
@@ -8,9 +8,9 @@ class abstraction_network:
 		self.num_abstract_states=num_abstract_states
 		self.learning_rate=params['learning_rate_for_abstraction_learning']
 
-		with tf.variable_scope('abstraction_scope'):
-			self.obs=tf.placeholder(tf.float32, [None, self.obs_size], name = 'obs')
-			self.Pr_a_given_z=tf.placeholder(tf.float32, [None,self.num_abstract_states], name = 'prob_of_all_a_given_z')
+		with tf.compat.v1.variable_scope('abstraction_scope'):
+			self.obs=tf.compat.v1.placeholder(tf.float32, [None, self.obs_size], name = 'obs')
+			self.Pr_a_given_z=tf.compat.v1.placeholder(tf.float32, [None,self.num_abstract_states], name = 'prob_of_all_a_given_z')
 			h=self.obs
 			for _ in range(params['abstraction_network_hidden_layers']):
 				h=tf.layers.dense(

--- a/experiments/policies/MountainCarPolicySB.py
+++ b/experiments/policies/MountainCarPolicySB.py
@@ -1,0 +1,61 @@
+import keras
+import sys
+import numpy as np
+from simple_rl.tasks import GymMDP
+import policies.Policy as Policy
+import os
+from stable_baselines3 import DQN
+
+
+
+class MountainCarPolicySB():
+    
+    def __init__(self, checkpoint, gym_env):    
+        self.checkpoint = checkpoint
+        self.gym_env = gym_env
+        self.model = DQN.load(checkpoint, env=gym_env)
+    
+    def get_params(self):
+		
+        params={}
+        params['env_name']="MountainCar-v0"
+        params['multitask']=True
+        params['obs_size']=self.gym_env.env.observation_space.shape[0]
+        params['num_iterations_for_abstraction_learning']=500
+        params['learning_rate_for_abstraction_learning']=0.001
+        params['abstraction_network_hidden_layers']=2
+        params['abstraction_network_hidden_nodes']=40
+        params['num_samples_from_demonstrator']=5000
+        params['episodes'] = 50
+        params['steps']=200
+        params['num_instances']=100
+        params['rl_learning_rate']=0.001
+    
+        return params
+
+    def expert_policy(self, state):
+        pass
+
+    def sample_unif_random(self, num_samples = 5000):
+        '''
+        Args:
+            mdp (simple_rl.MDP)
+            num_samples (int)
+            epsilon (float)
+
+        Returns:
+            (list): A collection of (s, a, mdp_id) tuples.
+        '''
+
+        samples = []
+
+        for _ in range(num_samples):
+            cur_state = self.gym_env.env.observation_space.sample()
+            self.gym_env.env.state = cur_state
+
+            # Get demo action.
+            best_action = self.demo_policy(cur_state)
+            #action_index = mdp.get_actions().index(best_action)
+            samples.append((cur_state, best_action, 0))
+
+        return samples

--- a/experiments/policies/MountainCarPolicySB.py
+++ b/experiments/policies/MountainCarPolicySB.py
@@ -10,10 +10,12 @@ from stable_baselines3 import DQN
 
 class MountainCarPolicySB():
     
-    def __init__(self, checkpoint, gym_env):    
+    def __init__(self, checkpoint, gym_env: GymMDP):    
         self.checkpoint = checkpoint
         self.gym_env = gym_env
-        self.model = DQN.load(checkpoint, env=gym_env)
+        self.model = DQN.load(checkpoint, env=gym_env.env)
+        self.params = self.get_params()
+        self.demo_policy = self.expert_policy
     
     def get_params(self):
 		
@@ -34,7 +36,12 @@ class MountainCarPolicySB():
         return params
 
     def expert_policy(self, state):
-        pass
+        
+        s_size=len(state)
+        s_array=np.array(state).reshape(1,s_size)
+        temp = self.model.predict(s_array)
+		
+        return np.argmax(temp[0])
 
     def sample_unif_random(self, num_samples = 5000):
         '''

--- a/experiments/run_learning_experiment.py
+++ b/experiments/run_learning_experiment.py
@@ -20,19 +20,23 @@ import policies.MountainCarPolicy as mpd
 import policies.AcrobotPolicy as abp
 import policies.LunarLanderPolicy as llps
 import policies.PendulumPolicy as pp
+import policies.MountainCarPolicySB as mpd_sb
+from huggingface_sb3 import load_from_hub
+
+
 # abstraction
 from .abstraction.NNStateAbstrClass import NNStateAbstr
 from .utils.experiment_utils import make_nn_sa, make_nn_sa_2
 
 import tensorflow as tf
-tf.disable_v2_behavior()
-tf.compat.v1.disable_eager_execution()
+# tf.compat.v1.disable_v2_behavior()
+# tf.compat.v1.disable_eager_execution()
 
 import warnings
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 
-def get_policy(gym_env: GymMDP):
+def get_policy(gym_env: GymMDP, sb3=False):
     """
     Args:
         gym_env (GymMDP)
@@ -48,13 +52,19 @@ def get_policy(gym_env: GymMDP):
     """
     if gym_env.env_name == "CartPole-v0":
         return cpp.CartPolePolicy(gym_env)
-    
+
     if gym_env.env_name == "Acrobot-v1":
         return abp.AcrobotPolicy(gym_env)
 
     if gym_env.env_name == "MountainCar-v0":
+        if sb3:
+            checkpoint = load_from_hub(
+                repo_id="sb3/dqn-MountainCar-v0",
+                filename="dqn-MountainCar-v0.zip")
+            return mpd_sb.MountainCarPolicySB(checkpoint, gym_env)
+
         return mpd.MountainCarPolicy(gym_env)
-    
+
     if gym_env.env_name == "LunarLander-v2":
         return llps.LunarLanderPolicy(gym_env)
 
@@ -72,12 +82,12 @@ def main(env_name, abstraction=True, verbose=False, seed=42):
         verbose = False (bool) : If True, print the environment name
         seed = 42 (int) :Seed for reproducibility
     Returns:
-        None 
+        None
     This function runs the learning experiment for the given environment.
     """
     ## get parameters
     gym_env = GymMDP(env_name)
-    
+
     ## Set seed
     gym_env.env.seed(seed)
     random.seed(seed)
@@ -86,15 +96,15 @@ def main(env_name, abstraction=True, verbose=False, seed=42):
         print("this is the environment: ", gym_env.env_name)
     ## Get actions and features
     actions = list(gym_env.get_actions())
-    
-    
+
+
     ## Get policy
-    policy = get_policy(gym_env)
+    policy = get_policy(gym_env, True)
     policy.params["num_mdps"] = 1
     policy.params["size_a"] = len(actions)
     policy.params["num_iterations_for_abstraction_learning"] = 10
     policy.params["steps"] = 20
-    
+
     ## Make Abstraction
     if abstraction:
         sess = tf.Session()
@@ -125,7 +135,7 @@ def main(env_name, abstraction=True, verbose=False, seed=42):
 
     # Timestamp for saving the experiment
     dir_for_plot = str(datetime.now().time()).replace(":", "_").replace(".", "_")
-    
+
     # mode
     # Run the experiment
     run_agents_on_mdp(agent_list,

--- a/experiments/run_learning_experiment.py
+++ b/experiments/run_learning_experiment.py
@@ -107,7 +107,7 @@ def main(env_name, abstraction=True, verbose=False, seed=42):
 
     ## Make Abstraction
     if abstraction:
-        sess = tf.Session()
+        sess = tf.compat.v1.Session()
         sample_batch = policy.sample_unif_random()
         abstraction_net = make_nn_sa_2(sess, policy.params, sample_batch)
         nn_sa = NNStateAbstr(abstraction_net)

--- a/experiments/run_learning_experiment.py
+++ b/experiments/run_learning_experiment.py
@@ -29,8 +29,9 @@ from .abstraction.NNStateAbstrClass import NNStateAbstr
 from .utils.experiment_utils import make_nn_sa, make_nn_sa_2
 
 import tensorflow as tf
-# tf.compat.v1.disable_v2_behavior()
-# tf.compat.v1.disable_eager_execution()
+# To make code compatible with old code implemented in tensorflow 1.x
+tf.compat.v1.disable_v2_behavior()
+tf.compat.v1.disable_eager_execution()
 
 import warnings
 warnings.filterwarnings("ignore", category=DeprecationWarning)

--- a/experiments/simple_rl/run_experiments.py
+++ b/experiments/simple_rl/run_experiments.py
@@ -55,7 +55,7 @@ def play_markov_game(agent_ls, markov_game_mdp, instances=10, episodes=100, step
 
     # Record how long each agent spends learning.
     print("Running experiment: \n" + str(experiment))
-    start = time.clock()
+    start = time.time()
 
     # For each instance of the agent.
     for instance in range(1, instances + 1):
@@ -114,7 +114,7 @@ def play_markov_game(agent_ls, markov_game_mdp, instances=10, episodes=100, step
             a.reset()
 
     # Time stuff.
-    print("Experiment took " + str(round(time.clock() - start, 2)) + " seconds.")
+    print("Experiment took " + str(round(time.time() - start, 2)) + " seconds.")
 
     experiment.make_plots(open_plot=open_plot)
 
@@ -166,14 +166,14 @@ def run_agents_lifelong(agents,
 
     # Record how long each agent spends learning.
     print("Running experiment: \n" + str(experiment))
-    start = time.clock()
+    start = time.time()
 
     times = defaultdict(float)
 
     # Learn.
     for agent in agents:
         print(str(agent) + " is learning.")
-        start = time.clock()
+        start = time.time()
 
         # --- SAMPLE NEW MDP ---
         for new_task in range(samples):
@@ -195,7 +195,7 @@ def run_agents_lifelong(agents,
             agent.reset()
 
         # Track how much time this agent took.
-        end = time.clock()
+        end = time.time()
         times[agent] = round(end - start, 3)
 
 
@@ -273,7 +273,7 @@ def run_agents_on_mdp(agents,
     for agent in agents:
         print(str(agent) + " is learning.")
 
-        start = time.clock()
+        start = time.time()
 
         # For each instance.
         for instance in range(1, instances + 1):
@@ -287,7 +287,7 @@ def run_agents_on_mdp(agents,
             mdp.end_of_instance()
 
         # Track how much time this agent took.
-        end = time.clock()
+        end = time.time()
         time_dict[agent] = round(end - start, 3)
         print()
 
@@ -327,7 +327,7 @@ def run_single_agent_on_mdp(agent, mdp, episodes, steps, experiment=None, verbos
         # Compute initial state/reward.
         state = mdp.get_init_state()
         reward = 0
-        episode_start_time = time.clock()
+        episode_start_time = time.time()
 
         # Extra printing if verbose.
         if verbose:
@@ -339,7 +339,7 @@ def run_single_agent_on_mdp(agent, mdp, episodes, steps, experiment=None, verbos
                 _increment_bar()
 
             # step time
-            step_start = time.clock()
+            step_start = time.time()
 
             # Compute the agent's policy.
             action = agent.act(state, reward)
@@ -352,7 +352,7 @@ def run_single_agent_on_mdp(agent, mdp, episodes, steps, experiment=None, verbos
                     # sys.stdout.write("x")
                 if episodes == 1 and not reset_at_terminal and experiment is not None and action != "terminate":
                     # Self loop if we're not episodic or resetting and in a terminal state.
-                    experiment.add_experience(agent, state, action, 0, state, time_taken=time.clock()-step_start)
+                    experiment.add_experience(agent, state, action, 0, state, time_taken=time.time()-step_start)
                     continue
                 break
 
@@ -368,7 +368,7 @@ def run_single_agent_on_mdp(agent, mdp, episodes, steps, experiment=None, verbos
                 reward_to_track = mdp.get_gamma()**(step + 1 + episode*steps) * reward if track_disc_reward else reward
                 reward_to_track = round(reward_to_track, 5)
 
-                experiment.add_experience(agent, state, action, reward_to_track, next_state, time_taken=time.clock() - step_start)
+                experiment.add_experience(agent, state, action, reward_to_track, next_state, time_taken=time.time() - step_start)
 
             if next_state.is_terminal():
                 if reset_at_terminal:

--- a/experiments/utils/experiment_utils.py
+++ b/experiments/utils/experiment_utils.py
@@ -112,7 +112,6 @@ def collect_samples_from_demo_policy_puddle(mdp_demo_policy_dict, num_samples, e
 
     return samples
 
-
 def collect_unif_random_samples_demo_policy_puddle(mdp_demo_policy_dict, num_samples):
     '''
     Args:
@@ -324,8 +323,8 @@ def make_nn_sa(mdp_demo_policy_dict, sess, params, verbose=True, sample_type="ra
     num_abstract_states = size_z
     dir_path = os.path.dirname(os.path.realpath(__file__))
     abstraction_net = abstraction_network.abstraction_network(sess, params,num_abstract_states)
-    sess.run(tf.global_variables_initializer())
-    saver = tf.train.Saver()
+    sess.run(tf.compat.v1.global_variables_initializer())
+    # saver = tf.train.Saver()
     if verbose:
         print("env_name:", params['env_name'])
     if params['env_name']=='PuddleMDP':
@@ -396,7 +395,7 @@ def make_nn_sa_2(sess, params, samples_batch=None, verbose=True):
     
     ## Create abstraction network
     abstraction_net = abstraction_network(sess, params,num_abstract_states)
-    sess.run(tf.global_variables_initializer())
+    sess.run(tf.compat.v1.global_variables_initializer())
     
     ## print
     if verbose:

--- a/mac/run.py
+++ b/mac/run.py
@@ -8,8 +8,8 @@ from keras import backend as K
 from .ActionWrapper import discretizing_wrapper
 from .HyperParameters import AlgorithmParameters, MetaParameters, make_parameters
 
-tf.disable_v2_behavior()
-tf.compat.v1.disable_eager_execution()
+# tf.compat.v1.disable_v2_behavior()
+# tf.compat.v1.disable_eager_execution()
 
 import warnings
 warnings.filterwarnings("ignore", category=DeprecationWarning)


### PR DESCRIPTION
Changed tensorflow so uses tensorflow 2.x, but uses the compat.v1 to use the old code

Implemeneted MoutainCar policy for one of stable-baselines3 models

Changed time.clock() to time.time(). time.clock() has been deprecated since python 3.3 😅 

