### PR TITLE
Name utils + fix

### DIFF
--- a/experiments/run_learning_experiment.py
+++ b/experiments/run_learning_experiment.py
@@ -196,8 +196,6 @@ def render_q_function(policy: PolicySB, actions, n_episodes=2, steps=1000):
                 break
             eval_env.render()
 
-
-
 def run_episodes_from_nn(env_name, abstraction_net: NNStateAbstr, seed: int,episodes=1, steps=500, verbose=True):
     """
     Args:
@@ -256,7 +254,6 @@ def create_abstraction_network(policy, num_samples=10000, x_train=None, verbose=
 
     start_time = time.time()
     batch_size = 32 
-    n_epochs = 100
     for epoch in range(n_epochs):
         for i in range(0, len(X), batch_size):
             Xbatch = X[i:i+batch_size]

--- a/experiments/utils/name_utils.py
+++ b/experiments/utils/name_utils.py
@@ -1,0 +1,42 @@
+import os
+from policies.PolicySB import PolicySB
+ABSTRACTION = "icml"
+def q_learning_function(policy: PolicySB):
+
+    q_learning_agent = "Q-learning"
+    env_name = "gym-" + policy.env_name 
+
+
+    retrieve_folder = get_retrieve_folder_results(policy)
+    file_name = policy.params['results_save_name'] + "_" + str(policy.seed) + ".csv" 
+
+
+def get_retrieve_folder_results(policy: PolicySB):
+    
+    retrieve_folder = "results/" + "gym-" + policy.env_name + "/" + str(policy.policy_train_episodes) + "/"
+    return retrieve_folder
+
+def get_agent_name(policy: PolicySB):
+    
+    if policy.k_bins > 1:
+        model = ABSTRACTION + "_" + str(policy.policy_train_episodes) + "_" + str(policy.k_bins) + "_" + policy.algo
+    else:    
+        model = ABSTRACTION + "_" + str(policy.policy_train_episodes) + "_" + policy.algo
+    
+    return model
+
+def get_new_results_file_name(policy: PolicySB):
+
+    new_save_folder = "results/" + ABSTRACTION + "/" + policy.env_name + "/" 
+    model = get_agent_name(policy)
+    new_save_name = model + "_" + str(policy.experiment_episodes) + "_" + str(policy.seed)
+    
+    if not os.path.exists(new_save_folder):
+        os.makedirs(new_save_folder)
+    
+    return new_save_name
+
+def get_new_save_folder(policy: PolicySB):
+    
+    new_save_folder = "results/" + ABSTRACTION + "/" + policy.env_name + "/" 
+    return new_save_folder


### PR DESCRIPTION
A file `name_utils` to generate all the names used in icml

Fix: number of epoch was sat in function, instead of using epoch from policy params 